### PR TITLE
Add enum converter and fix ResultSet memory leak

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,15 @@ jooq {
             generate {
                 jpaAnnotations = true
             }
+            database {
+                forcedTypes {
+                    forcedType {
+                        userType = 'example.jooq.domain.Pet.PetType'
+                        converter = 'example.jooq.converters.PetTypeConverter'
+                        includeExpression = 'PET\\.TYPE'
+                    }
+                }
+            }
         }
     }
 }

--- a/src/main/java/example/jooq/Application.java
+++ b/src/main/java/example/jooq/Application.java
@@ -49,19 +49,19 @@ public class Application {
         PetRecord dino = context.newRecord(PET);
         dino.setName("Dino");
         dino.setOwnerId(fred.getId());
-        dino.setType(Pet.PetType.DOG.name());
+        dino.setType(Pet.PetType.DOG);
         dino.store();
 
         PetRecord babyPuss = context.newRecord(PET);
         babyPuss.setName("Baby Puss");
         babyPuss.setOwnerId(fred.getId());
-        babyPuss.setType(Pet.PetType.CAT.name());
+        babyPuss.setType(Pet.PetType.CAT);
         babyPuss.store();
 
         PetRecord hoppy = context.newRecord(PET);
         hoppy.setName("Hoppy");
         hoppy.setOwnerId(barney.getId());
-        hoppy.setType(Pet.PetType.DOG.name());
+        hoppy.setType(Pet.PetType.DOG);
         hoppy.store();
     }
 }

--- a/src/main/java/example/jooq/converters/PetTypeConverter.java
+++ b/src/main/java/example/jooq/converters/PetTypeConverter.java
@@ -1,0 +1,10 @@
+package example.jooq.converters;
+
+import example.jooq.domain.Pet;
+import org.jooq.impl.EnumConverter;
+
+public class PetTypeConverter extends EnumConverter<String, Pet.PetType> {
+    public PetTypeConverter() {
+        super(String.class, Pet.PetType.class);
+    }
+}

--- a/src/main/java/example/jooq/repositories/OwnerRepository.java
+++ b/src/main/java/example/jooq/repositories/OwnerRepository.java
@@ -2,6 +2,7 @@ package example.jooq.repositories;
 
 import example.jooq.domain.Owner;
 import org.jooq.DSLContext;
+import org.jooq.ResultQuery;
 import org.simpleflatmapper.jdbc.DynamicJdbcMapper;
 import org.simpleflatmapper.jdbc.JdbcMapperFactory;
 
@@ -32,13 +33,14 @@ public class OwnerRepository {
     }
 
     public Optional<Owner> findByName(String name) throws SQLException {
-        ResultSet rs = context.select(OWNER.ID, OWNER.NAME, OWNER.AGE)
+        ResultQuery<?> query = context.select(OWNER.ID, OWNER.NAME, OWNER.AGE)
                 .from(OWNER)
                 .join(PET)
                 .on(PET.OWNER_ID.eq(OWNER.ID))
-                .where(OWNER.NAME.eq(name))
-                .fetchResultSet();
+                .where(OWNER.NAME.eq(name));
 
-        return mapper.stream(rs).findFirst();
+        try (ResultSet rs = query.fetchResultSet()) {
+            return mapper.stream(rs).findFirst();
+        }
     }
 }

--- a/src/main/java/example/jooq/repositories/OwnerRepository.java
+++ b/src/main/java/example/jooq/repositories/OwnerRepository.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static example.jooq.domain.Tables.OWNER;
-import static example.jooq.domain.tables.Pet.PET;
 
 @Singleton
 public class OwnerRepository {

--- a/src/main/java/example/jooq/repositories/OwnerRepository.java
+++ b/src/main/java/example/jooq/repositories/OwnerRepository.java
@@ -35,8 +35,6 @@ public class OwnerRepository {
     public Optional<Owner> findByName(String name) throws SQLException {
         ResultQuery<?> query = context.select(OWNER.ID, OWNER.NAME, OWNER.AGE)
                 .from(OWNER)
-                .join(PET)
-                .on(PET.OWNER_ID.eq(OWNER.ID))
                 .where(OWNER.NAME.eq(name));
 
         try (ResultSet rs = query.fetchResultSet()) {

--- a/src/main/java/example/jooq/repositories/PetRepository.java
+++ b/src/main/java/example/jooq/repositories/PetRepository.java
@@ -3,6 +3,7 @@ package example.jooq.repositories;
 import example.jooq.domain.NameDTO;
 import example.jooq.domain.PetWithOwner;
 import org.jooq.DSLContext;
+import org.jooq.ResultQuery;
 import org.simpleflatmapper.jdbc.DynamicJdbcMapper;
 import org.simpleflatmapper.jdbc.JdbcMapperFactory;
 
@@ -33,14 +34,15 @@ public class PetRepository {
     }
 
     public Optional<PetWithOwner> findByName(String name) throws SQLException {
-        ResultSet rs = context.select(PET.ID, PET.NAME)
+        ResultQuery<?> query = context.select(PET.ID, PET.NAME, PET.TYPE)
                 .select(OWNER.ID.as("owner_id"), OWNER.NAME.as("owner_name"), OWNER.AGE.as("owner_age"))
                 .from(PET)
                 .join(OWNER)
                 .on(PET.OWNER_ID.eq(OWNER.ID))
-                .where(PET.NAME.eq(name))
-                .fetchResultSet();
+                .where(PET.NAME.eq(name));
 
-        return mapper.stream(rs).findFirst();
+        try (ResultSet rs = query.fetchResultSet()) {
+            return mapper.stream(rs).findFirst();
+        }
     }
 }


### PR DESCRIPTION
@ilopmar can you look, please?

- I left the `stream` part (#3), SimpleFlatMapper needs streaming of ResultSet, because it can map nested 1:N (more rows into single DTO)
- It hopefully resolves your unhappinnes with PetType https://github.com/micronaut-graal-tests/micronaut-jooq-graal/issues/2#issuecomment-646471812, if I understood it correctly