### PR TITLE
[Postgres] Cleanup build.gradle after latest changes in micronaut-sql project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,10 +36,7 @@ dependencies {
     implementation "io.micronaut:micronaut-runtime"
     implementation "io.micronaut:micronaut-http-client"
     implementation "io.micronaut:micronaut-http-server-netty"
-    implementation "jakarta.persistence:jakarta.persistence-api:2.2.2"
-    implementation "io.micronaut.sql:micronaut-jooq", {
-        exclude group: 'io.micronaut', module: 'micronaut-jdbc'
-    }
+    implementation "io.micronaut.sql:micronaut-jooq"
     implementation "io.micronaut.flyway:micronaut-flyway"
     implementation "org.simpleflatmapper:sfm-jdbc:8.2.3"
 

--- a/src/main/resources/META-INF/native-image/example.jooq/example-jooq/native-image.properties
+++ b/src/main/resources/META-INF/native-image/example.jooq/example-jooq/native-image.properties
@@ -1,4 +1,3 @@
 Args = -H:Name=mn-jooq-graal-postgres \
        -H:Class=example.jooq.Application \
-       -H:+RemoveSaturatedTypeFlows \
-       --report-unsupported-elements-at-runtime
+       -H:+RemoveSaturatedTypeFlows


### PR DESCRIPTION
Replaces https://github.com/micronaut-graal-tests/micronaut-jooq-graal/pull/5

Should wait for 
- possible merge of https://github.com/micronaut-projects/micronaut-sql/pull/218
- creating new release of `micronaut-sql` project
- propagation of this new release into `micronaut-bom`
