### PR TITLE
[H2] Cleanup build.gradle after latest changes in micronaut-sql project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,10 +35,7 @@ dependencies {
     implementation "io.micronaut:micronaut-runtime"
     implementation "io.micronaut:micronaut-http-client"
     implementation "io.micronaut:micronaut-http-server-netty"
-    implementation "jakarta.persistence:jakarta.persistence-api:2.2.2"
-    implementation "io.micronaut.sql:micronaut-jooq", {
-        exclude group: 'io.micronaut', module: 'micronaut-jdbc'
-    }
+    implementation "io.micronaut.sql:micronaut-jooq"
     implementation "org.simpleflatmapper:sfm-jdbc:8.2.3"
 
     runtime "io.micronaut.sql:micronaut-jdbc-hikari"


### PR DESCRIPTION
Replaces https://github.com/micronaut-graal-tests/micronaut-jooq-graal/pull/5

Should wait for 
- possible merge of https://github.com/micronaut-projects/micronaut-sql/pull/218
- creating new release of `micronaut-sql` project
- propagation of this new release into `micronaut-bom`
